### PR TITLE
Revert "Update Helm release etcd to v12" 

### DIFF
--- a/dns/Chart.yaml
+++ b/dns/Chart.yaml
@@ -27,5 +27,5 @@ dependencies:
     version: 1.41.0
     repository: https://coredns.github.io/helm
   - name: etcd
-    version: 12.0.18
+    version: 11.3.0
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Reverts flx5/argocd-apps#41

Bitnami pulled their images off docker hub....